### PR TITLE
Relieve Symfony version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "php-pm/httpkernel-adapter",
     "require": {
         "stack/builder": "1.0.*",
-        "symfony/http-foundation": "2.6.*",
-        "symfony/http-kernel": "2.6.*"
+        "symfony/http-foundation": "~2.6",
+        "symfony/http-kernel": "~2.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Necessary as Symfony 2.7 has just been released. 