### PR TITLE
Support autoload mechanism of Symfony standard

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -32,6 +32,13 @@ class Symfony implements StackableBootstrapInterface
             require_once './app/AppKernel.php';
         }
 
+        $info = new \ReflectionClass('AppKernel');
+        $appDir = dirname($info->getFileName());
+        $symfonyAutoload = $appDir . '/autoload.php';
+        if (is_file($symfonyAutoload)) {
+            require_once $symfonyAutoload;
+        }
+
         $app = new \AppKernel($this->appenv, false);
         $app->loadClassCache();
 

--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -3,7 +3,6 @@
 namespace PHPPM\Bootstraps;
 
 use Stack\Builder;
-use Symfony\Component\HttpKernel\HttpCache\Store;
 
 /**
  * A default bootstrap for the Symfony framework

--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -32,12 +32,7 @@ class Symfony implements StackableBootstrapInterface
             require_once './app/AppKernel.php';
         }
 
-        $info = new \ReflectionClass('AppKernel');
-        $appDir = dirname($info->getFileName());
-        $symfonyAutoload = $appDir . '/autoload.php';
-        if (is_file($symfonyAutoload)) {
-            require_once $symfonyAutoload;
-        }
+        $this->includeAutoload();
 
         $app = new \AppKernel($this->appenv, false);
         $app->loadClassCache();
@@ -51,5 +46,23 @@ class Symfony implements StackableBootstrapInterface
     public function getStack(Builder $stack)
     {
         return $stack;
+    }
+
+    /**
+     * Includes the autoload file from the app directory, if available.
+     *
+     * The Symfony standard edition configures the annotation class loading
+     * in that file.
+     * The alternative bootstrap.php.cache cannot be included as that leads
+     * to "Cannot redeclare class" error, when starting php-pm.
+     */
+    protected function includeAutoload()
+    {
+        $info = new \ReflectionClass('AppKernel');
+        $appDir = dirname($info->getFileName());
+        $symfonyAutoload = $appDir . '/autoload.php';
+        if (is_file($symfonyAutoload)) {
+            require_once $symfonyAutoload;
+        }
     }
 }


### PR DESCRIPTION
The Symfony standard edition uses a special [autoload.php](https://github.com/symfony/symfony-standard/blob/2.8/app/autoload.php), which is also used to initialize the loading of annotation classes.

This pull request adds support for the mentioned autoload file and, therefore, makes php-pm easier to use with a Symfony standard edition.
Without these changes, requests fail whenever a (not loaded) annotation is encountered.
