### PR TITLE
Bootstrap fixes

### DIFF
--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -17,7 +17,7 @@ class Laravel implements StackableBootstrapInterface
     /**
      * Store the application
      *
-     * @var Symfony\Component\HttpKernel\HttpKernelInterface
+     * @var \Symfony\Component\HttpKernel\HttpKernelInterface
      */
     protected $app;
 

--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -23,6 +23,7 @@ class Laravel implements StackableBootstrapInterface
 
     /**
      * Instantiate the bootstrap, storing the $appenv
+     * @param string|null $appenv The environment your application will use to bootstrap (if any)
      */
     public function __construct($appenv)
     {

--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -31,20 +31,28 @@ class Laravel implements StackableBootstrapInterface
     }
 
     /**
-     * Create a Symfony application
+     * Create a Laravel application
      */
     public function getApplication()
     {
-        if (file_exists(__DIR__ . '/autoload.php') && file_exists(__DIR__ . '/start.php')) {
-            require_once __DIR__ . '/autoload.php';
-            $this->app = require_once __DIR__ . '/start.php';
+        // Laravel 5 / Lumen
+        if (file_exists('bootstrap/app.php')) {
+            return $this->app = require_once 'bootstrap/app.php';
         }
 
-        return $this->app;
+        // Laravel 4
+        if (file_exists('bootstrap/start.php')) {
+            require_once 'bootstrap/autoload.php';
+            return $this->app = require_once 'bootstrap/start.php';
+        }
+
+        throw new \RuntimeException('Laravel bootstrap file not found');
     }
 
     /**
      * Return the StackPHP stack.
+     * @param Builder $stack
+     * @return Builder
      */
     public function getStack(Builder $stack)
     {

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -18,7 +18,7 @@ class HttpKernel implements BridgeInterface
     /**
      * An application implementing the HttpKernelInterface
      *
-     * @var \Symfony\Component\HttpFoundation\HttpKernelInterface
+     * @var \Symfony\Component\HttpKernel\HttpKernelInterface
      */
     protected $application;
 

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -44,12 +44,7 @@ class HttpKernel implements BridgeInterface
             require_once $autoloader;
         }
 
-        if (false === class_exists($appBootstrap)) {
-            $appBootstrap = '\\' . $appBootstrap;
-            if (false === class_exists($appBootstrap)) {
-                throw new \RuntimeException('Could not find bootstrap class ' . $appBootstrap);
-            }
-        }
+        $appBootstrap = $this->normalizeAppBootstrap($appBootstrap);
 
         $bootstrap = new $appBootstrap($appenv);
 
@@ -164,5 +159,23 @@ class HttpKernel implements BridgeInterface
         }
 
         $reactResponse->end($content);
+    }
+
+    /**
+     * @param $appBootstrap
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function normalizeAppBootstrap($appBootstrap)
+    {
+        $appBootstrap = str_replace('\\\\', '\\', $appBootstrap);
+        if (false === class_exists($appBootstrap)) {
+            $appBootstrap = '\\' . $appBootstrap;
+            if (false === class_exists($appBootstrap)) {
+                throw new \RuntimeException('Could not find bootstrap class ' . $appBootstrap);
+            }
+            return $appBootstrap;
+        }
+        return $appBootstrap;
     }
 }

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -33,7 +33,7 @@ class HttpKernel implements BridgeInterface
      * be able to be autoloaded.
      *
      * @param string $appBootstrap The name of the class used to bootstrap the application
-     * @param string|null $appBootstrap The environment your application will use to bootstrap (if any)
+     * @param string|null $appenv The environment your application will use to bootstrap (if any)
      * @see http://stackphp.com
      */
     public function bootstrap($appBootstrap, $appenv)


### PR DESCRIPTION
Issues this fixes:

- launching with args like this causes a 'cannot redeclare class' error:
```
vendor/bin/ppm start --bridge=httpKernel --bootstrap='PHPPM\\Bootstraps\\Laravel'
```
(note the duplicate slashes)

- Laravel bootstrap only works for Laravel 4.  

- Laravel bootstrap will allow the server to start with the app set to null.

- Laravel bootstrap assumes the working directory is the `/bootstrap` folder instead of the project root.