### PR TITLE
Add initial cookie support in \PHPPM\Bridges\HttpKernel::mapRequest().

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -122,9 +122,17 @@ class HttpKernel implements BridgeInterface
             parse_str($content, $post);
         }
 
+        $cookies = array();
+        if (null !== ($headersCookie = $headers['Cookie'])) {
+          foreach (explode(';', $headersCookie) as $cookie) {
+            list($name, $value) = explode('=', trim($cookie));
+            $cookies[$name] = $value;
+          }
+        }
+
         $syRequest = new SymfonyRequest(
             // $query, $request, $attributes, $cookies, $files, $server, $content
-            $query, $post, array(), array(), array(), array(), $content
+            $query, $post, array(), $cookies, array(), array(), $content
         );
 
         $syRequest->setMethod($method);


### PR DESCRIPTION
Adds support for cookies when creating `SymfonyRequest` from `ReactRequest` for issue https://github.com/php-pm/php-pm/issues/55.
(cherry picked from commit 1c1a55d8ba313f800bfef703cfbbb3dbed74f3d9)