### PR TITLE
Fix "Undefined index: Cookie".

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -123,8 +123,9 @@ class HttpKernel implements BridgeInterface
         }
 
         $cookies = array();
-        if (null !== ($headersCookie = $headers['Cookie'])) {
-          foreach (explode(';', $headersCookie) as $cookie) {
+        if (isset($headers['Cookie'])) {
+          $headersCookie = explode(';', $headers['Cookie']);
+          foreach ($headersCookie as $cookie) {
             list($name, $value) = explode('=', trim($cookie));
             $cookies[$name] = $value;
           }


### PR DESCRIPTION
Fix "Undefined index: Cookie" error in [last pull request](https://github.com/php-pm/php-pm-httpkernel/pull/12#issuecomment-174289471).  Confirmed behavior with cookies disabled / enabled in browser.