### PR TITLE
Used autoloaded AppKernel

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -33,10 +33,6 @@ class Symfony implements BootstrapInterface
      */
     public function getApplication()
     {
-        if (file_exists('./app/AppKernel.php')) {
-            require_once './app/AppKernel.php';
-        }
-
         $this->includeAutoload();
 
         $app = new SymfonyAppKernel($this->appenv, $this->debug); //which extends \AppKernel

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ HttpKernel adapter for use of Symfony and Laravel frameworks with PHP-PM. See ht
 
         composer require php-pm/httpkernel-adapter:dev-master
 
-> **Note**: Make sure your `AppKernel` is autoloaded in your `composer.json`:
+> **Note**: For Symfony, make sure your `AppKernel` is autoloaded in your
+> `composer.json` (shouldn't be an issue for projects created using the Standard
+> Edition after November 2015):
 >
 > ```
 > {

--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ HttpKernel adapter for use of Symfony and Laravel frameworks with PHP-PM. See ht
 
         composer require php-pm/httpkernel-adapter:dev-master
 
+> **Note**: Make sure your `AppKernel` is autoloaded in your `composer.json`:
+>
+> ```
+> {
+>     "autoload": {
+>         "classmap": ["app/AppKernel.php"]
+>     }
+> }
+> ```


### PR DESCRIPTION
Composer is perfectly capable of autoloading AppKernel (via the `classmap` autoloader), this is the approach used in the [Symfony Standard Edition](https://github.com/symfony/symfony-standard/blob/05bca699ef631d03d4b114b4366ad0c180b55ecb/composer.json#L8).