### PR TITLE
Preload services

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -3,6 +3,7 @@
 namespace PHPPM\Bootstraps;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * A default bootstrap for the Symfony framework
@@ -59,6 +60,7 @@ class Symfony implements BootstrapInterface, HooksInterface
         $request = new Request();
         $request->setMethod(Request::METHOD_HEAD);
         $app->handle($request);
+        $this->preloadServices($app);
 
         return $app;
     }
@@ -96,6 +98,25 @@ class Symfony implements BootstrapInterface, HooksInterface
             // since Symfony does not reset Profiler::disable() calls after each request, we need to do it,
             // so the profiler bar is visible after the second request as well.
             $app->getContainer()->get('profiler')->enable();
+        }
+    }
+
+    /**
+     * Instantiate all services in the Dependency Injection Container.
+     *
+     * Stateless (shared) services in the Dependency Injection Container will be
+     * instantiated once by the first Request that require them, and then their
+     * instance will be reused in all other Requests.
+     * This also allows to "warm up" part of autoloading.
+     *
+     * @param KernelInterface $kernel
+     */
+    protected function preloadServices(KernelInterface $kernel)
+    {
+        $kernel->boot();
+        $container = $kernel->getContainer();
+        foreach ($container->getServiceIds() as $serviceId) {
+            $container->get($serviceId);
         }
     }
 }


### PR DESCRIPTION
Instantiate all services in the Dependency Injection Container.

Stateless (shared) services in the Dependency Injection Container will be instantiated once by the first Request that require them, and then their instance will be reused in all other Requests.

This also allows to "warm up" part of autoloading.