### PR TITLE
Add php native authorization headers

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -10,7 +10,6 @@ use PHPPM\Utils;
 use React\Http\Request as ReactRequest;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse as SymfonyStreamedResponse;
 use Symfony\Component\HttpKernel\TerminableInterface;

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -150,6 +150,20 @@ class HttpKernel implements BridgeInterface
             session_id(Utils::generateSessionId());
         }
 
+        if (isset($headers['Authorization'])) {
+            $authorizationHeader = $headers['Authorization'];
+            $authorizationHeaderParts = explode(' ', $authorizationHeader);
+            $type = $authorizationHeaderParts[0];
+            if (($type === 'Basic' || $type === 'Digest') && isset($authorizationHeaderParts[1])) {
+                $credentials = base64_decode($authorizationHeaderParts[1]);
+                $credentialsParts = explode(':', $credentials);
+                $nativeAuthorizationHeaders['PHP_AUTH_USER'] = isset($credentialsParts[0]) ? $credentialsParts[0] : '';
+                $nativeAuthorizationHeaders['PHP_AUTH_PW'] = isset($credentialsParts[1]) ? $credentialsParts[1] : '';
+                $nativeAuthorizationHeaders['AUTH_TYPE'] = $type;
+                $headers = array_merge($headers, $nativeAuthorizationHeaders);
+            }
+        }
+
         $files = $reactRequest->getFiles();
         $post = $reactRequest->getPost();
 


### PR DESCRIPTION
Hi! We faced with missing php headers during basic authentication, so Symfony BasicAuthenticationListener could not work correctly. In this PR i propose to add appropriate headers.