### PR TITLE
Fixes Laravel 4 support

### DIFF
--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -68,6 +68,9 @@ class Laravel implements BootstrapInterface, HooksInterface, RequestClassProvide
         // Laravel 4
         if (file_exists('bootstrap/start.php')) {
             $this->app = require_once 'bootstrap/start.php';
+            $this->app->boot();
+            
+            return $this->app;
         }
 
         if (!$this->app) {


### PR DESCRIPTION
It would appear in the last few commits support for Laravel 4 was broken. This fix simply returns early using the code that was there previously.