### PR TITLE
Change access to Metadata Bag

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -73,7 +73,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
         $nativeStorage = new StrongerNativeSessionStorage(
             $app->getContainer()->getParameter('session.storage.options'),
             $app->getContainer()->has('session.handler') ? $app->getContainer()->get('session.handler'): null,
-            $app->getContainer()->get('session.storage.metadata_bag')
+            $app->getContainer()->get('session.storage')->getMetadataBag()
         );
         $app->getContainer()->set('session.storage.native', $nativeStorage);
 


### PR DESCRIPTION
Hello, this patch uses the built in method `getMetadataBag()` instead of accessing the `session.storage.metadata_bag` from the container.

Requesting the "session.storage.metadata_bag" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.

In case I've missed something let me know.