### PR TITLE
Fixes for Laravel Session, reset between requests

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -111,10 +111,10 @@ class HttpKernel implements BridgeInterface
         if ($this->application instanceof TerminableInterface) {
             $this->application->terminate($syRequest, $syResponse);
         }
-	
-	    if ($this->application instanceof Kernel) {
-		    $this->application->terminate($syRequest, $syResponse);
-	    }
+        
+        if ($this->application instanceof Kernel) {
+            $this->application->terminate($syRequest, $syResponse);
+        }
 
         if ($this->bootstrap instanceof HooksInterface) {
             $this->bootstrap->postHandle($this->application);

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse as SymfonyStreamedResponse;
 use Symfony\Component\HttpKernel\TerminableInterface;
+use Illuminate\Contracts\Http\Kernel;
 
 class HttpKernel implements BridgeInterface
 {
@@ -111,7 +112,7 @@ class HttpKernel implements BridgeInterface
             $this->application->terminate($syRequest, $syResponse);
         }
 	
-	    if (is_a($this->application, '\Illuminate\Contracts\Http\Kernel')) {
+	    if ($this->application instanceof Kernel) {
 		    $this->application->terminate($syRequest, $syResponse);
 	    }
 

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -110,6 +110,10 @@ class HttpKernel implements BridgeInterface
         if ($this->application instanceof TerminableInterface) {
             $this->application->terminate($syRequest, $syResponse);
         }
+	
+	    if (is_a($this->application, '\Illuminate\Contracts\Http\Kernel')) {
+		    $this->application->terminate($syRequest, $syResponse);
+	    }
 
         if ($this->bootstrap instanceof HooksInterface) {
             $this->bootstrap->postHandle($this->application);

--- a/Laravel/SessionGuard.php
+++ b/Laravel/SessionGuard.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PHPPM\Laravel;
+
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Foundation\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionGuard extends \Illuminate\Auth\SessionGuard
+{
+	
+	/**
+	 * App instance
+	 *
+	 * @var mixed|\Illuminate\Foundation\Application $app
+	 */
+	protected $app;
+	
+	/**
+	 * Create a new authentication guard.
+	 *
+	 * @param  string  $name
+	 * @param  \Illuminate\Contracts\Auth\UserProvider  $provider
+	 * @param  \Symfony\Component\HttpFoundation\Session\SessionInterface  $session
+	 * @param  \Symfony\Component\HttpFoundation\Request  $request
+	 * @param  mixed|\Illuminate\Foundation\Application $app
+	 * @return void
+	 */
+	public function __construct($name,
+	                            UserProvider $provider,
+	                            SessionInterface $session,
+	                            Request $request = null,
+	                            Application $app)
+	{
+		$this->name = $name;
+		$this->session = $session;
+		$this->request = $request;
+		$this->provider = $provider;
+		$this->app = $app;
+	}
+	
+	/**
+	 * Set the current request instance.
+	 *
+	 * @param  \Symfony\Component\HttpFoundation\Request  $request
+	 * @return $this
+	 */
+	public function setRequest(Request $request)
+	{
+		// reset the current state
+		$this->reset();
+		
+		// retrieve a new session from the app
+		$this->session = $this->app->make('session');
+		
+		return parent::setRequest($request);
+	}
+	
+	/**
+	 * Reset the state of current class instance.
+	 *
+	 * @return void
+	 */
+	protected function reset()
+	{
+		$this->user = null;
+		$this->lastAttempted = null;
+		$this->viaRemember = false;
+		$this->loggedOut = false;
+		$this->tokenRetrievalAttempted = false;
+	}
+}


### PR DESCRIPTION
I make this pull request to complete the work done by duxet 1 year ago on pull request #39 .
I tried to implement his work but unfortunately the issue with auth persists. Specifically, when I login using standard Laravel authentication, if I open another browser (cookie cleared, clean session), I am directly logged in.
It seems that this happens because the standard Laravel Session is a singleton, and persists between requests. I adapted #39 code and added an extension to make session.storage no more singleton, and now the session is reloaded at each request.
This has been tested, by now, with Laravel 5.3. 