### PR TITLE
Check logger method if default is used instead of monolog

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -170,7 +170,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
             if ($container->has('logger')) {
                 $logger = $container->get('logger');
                 Utils::bindAndCall(function () {
-                    if ($debugLogger = $this->getDebugLogger()) {
+                    if (\method_exists($this, 'getDebugLogger') && $debugLogger = $this->getDebugLogger()) {
                         //DebugLogger
                         Utils::hijackProperty($debugLogger, 'records', []);
                     }


### PR DESCRIPTION
Method is available only in symfony/monolog-bridge logger so it is better to check existence instead of requiring whole package. Fix error from #81 