### PR TITLE
Fix issue with cookies with no "="

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -138,6 +138,9 @@ class HttpKernel implements BridgeInterface
             $cookies = explode(';', $cookieHeader);
 
             foreach ($cookies as $cookie) {
+                if (strpos($cookie, '=') == false) {
+                    continue;
+                }
                 list($name, $value) = explode('=', trim($cookie));
                 $_COOKIE[$name] = $value;
 


### PR DESCRIPTION
Hi,

When testing this on our system, I was seeing an empty cookie header come though on some of our requests. This caused an issue on line 141. Checking for an equals sign first seems to fix the issue and makes this a little more robust.