### PR TITLE
Add lumen dirty check

### DIFF
--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -113,11 +113,15 @@ class Laravel implements BootstrapInterface, HooksInterface, RequestClassProvide
      * @param \Illuminate\Contracts\Foundation\Application $app
      */
     public function postHandle($app)
-    {
-        //reset debugbar if available
-
-        $this->resetProvider('\Illuminate\Cookie\CookieServiceProvider');
-        $this->resetProvider('\Illuminate\Session\SessionServiceProvider');
+    {   
+        //check if this is a lumen framework, if so, do not reset
+        //note that lumen does not have the getProvider method
+        if (method_exists($this->app, 'getProvider')) {
+            //reset debugbar if available
+            $this->resetProvider('\Illuminate\Cookie\CookieServiceProvider');
+            $this->resetProvider('\Illuminate\Session\SessionServiceProvider');
+        }
+       
     }
 
     /**


### PR DESCRIPTION
Do not reset providers if lumen is present. 
Lumen does not use any session/cookie middleware since it's a pure API framework. Thus, these two providers can be safely disregarded.