### PR TITLE
Adds `Max-Age` cookie support

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -262,6 +262,10 @@ class HttpKernel implements BridgeInterface
                 $cookieHeader .= '; Expires=' . gmdate('D, d-M-Y H:i:s', $cookie->getExpiresTime()). ' GMT';
             }
 
+            if ($cookie->getMaxAge()) {
+                $cookieHeader .= '; Max-Age=' . $cookie->getMaxAge();
+            }
+
             if ($cookie->isSecure()) {
                 $cookieHeader .= '; Secure';
             }


### PR DESCRIPTION
Laravel uses the Max-Age cookie property and I noticed it was missing.

This PR adds support for the `Max-Age` property when constructing the $cookies[] array in `mapResponse()`.