### PR TITLE
Fix native session handling.

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -276,8 +276,8 @@ class HttpKernel implements BridgeInterface
             $cookies[] = $cookieHeader;
         }
 
-        if (isset($headers['Set-Cookie'])) {
-            $headers['Set-Cookie'] = array_merge((array)$headers['Set-Cookie'], $cookies);
+        if (isset($nativeHeaders['Set-Cookie'])) {
+            $headers['Set-Cookie'] = array_merge((array)$nativeHeaders['Set-Cookie'], $cookies);
         } else {
             $headers['Set-Cookie'] = $cookies;
         }


### PR DESCRIPTION
After merging the headers, make sure that the native session cookie is present.

Without this fix, the session cookie (from headers_list()) is overridden by Symfony cookies, like the remember-me cookie.

Tested with Symfony 4.1 and PHP 7.1