### PR TITLE
Enable trusted proxies in Symfony >= 3.3

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -80,6 +80,14 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
             $app->booted = true;
         }, $app);
 
+        if ($trustedProxies = isset($_SERVER['TRUSTED_PROXIES']) ? $_SERVER['TRUSTED_PROXIES'] : false) {
+            Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+        }
+
+        if ($trustedHosts = isset($_SERVER['TRUSTED_HOSTS']) ? $_SERVER['TRUSTED_HOSTS'] : false) {
+            Request::setTrustedHosts(explode(',', $trustedHosts));
+        }
+
         return $app;
     }
 


### PR DESCRIPTION
Fixes php-pm issue #257 & requires Symfony 3.3.
In my case, this is needed to detect whether HTTPS is used or not. Using nginx as reverse proxy.
The code is directly copy pasted from Symfony 4.x index.php.