### PR TITLE
Fix empty file inputs in Symfony 4.1

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -159,7 +159,13 @@ class HttpKernel implements BridgeInterface
                     $this->tempFiles[] = $tmpname;
 
                     if (UPLOAD_ERR_NO_FILE == $file->getError()) {
-                        $file = null;
+                        $file = [
+                            'error' => $file->getError(),
+                            'name' => $file->getClientFilename(),
+                            'size' => $file->getSize(),
+                            'tmp_name' => $tmpname,
+                            'type' => $file->getClientMediaType()
+                        ];
                     } else {
                         if (UPLOAD_ERR_OK == $file->getError()) {
                             file_put_contents($tmpname, (string)$file->getStream());


### PR DESCRIPTION
Symfony 4.1 fails on uploaded files that are null: they must be array
or UploadedFile. UploadedFile can only be used for actual files.
Solution is to pass the uploaded file as array instead.

The array cannot be passed for actual uploaded files because Symfony
will not trust the files because they were not created by PHP core.

A better solution would be to let Symfony accept null files (see
implementation of FileBag).