### PR TITLE
Reset doctrine object manager at the end of the request if closed

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -111,6 +111,13 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
     {
         $container = $app->getContainer();
 
+        if ($container->has('debug.stopwatch')) {
+            $em = $container->get("doctrine");
+            if (!$em->getManager()->isOpen()) {
+                $em->resetManager();
+            }
+        }
+
         //resets stopwatch, so it can correctly calculate the execution time
         if ($container->has('debug.stopwatch')) {
             $container->get('debug.stopwatch')->__construct();

--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -111,7 +111,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
     {
         $container = $app->getContainer();
 
-        if ($container->has('debug.stopwatch')) {
+        if ($container->has('doctrine')) {
             $em = $container->get("doctrine");
             if (!$em->getManager()->isOpen()) {
                 $em->resetManager();


### PR DESCRIPTION
Putting this up for discussion. This prevents the "Entity manager is closed" error from propagating to future requests. Using this together with https://github.com/facile-it/doctrine-mysql-come-back on my project I have not had any database related issues in the past few weeks.