### PR TITLE
Clear the doctrine entity manager in every request

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -137,6 +137,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
             if (!$em->getManager()->isOpen()) {
                 $em->resetManager();
             }
+            $em->getManager()->clear();
         }
 
         //resets stopwatch, so it can correctly calculate the execution time

--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -136,8 +136,9 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
             $em = $container->get("doctrine");
             if (!$em->getManager()->isOpen()) {
                 $em->resetManager();
+            } else {
+                $em->getManager()->clear();
             }
-            $em->getManager()->clear();
         }
 
         //resets stopwatch, so it can correctly calculate the execution time


### PR DESCRIPTION
I have been trying a lot to find an alternative to this, but unfortunately not clearing Doctrine at the end of the request causes 2 major issues:

- Once an entity is fetched from the database, Doctrine will not fetch it again in the next request, but reuse the same entity. This is good for performance, but makes it extremely easy to have inconsistent state, because any changes made to an entity or a child collection will get carried over to the next request, regardless if the entity was persisted or not. This causes bugs like https://github.com/Sylius/Sylius/issues/9629 that are both very hard to track down and to fix.

- Because entities are cached and not fetched again in the next request, any changes made to the database from an external source (e.g. a worker or third party script) are not detected by the app, which continues to use the cached version of the entity as long as the worker remains alive.

This PR fixes this by clearing the entity manager at the end of each request, so that fresh queries will be performed in the next.