### PR TITLE
Support BinaryFileResponse and custom streaming response classes.

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -289,14 +289,8 @@ class HttpKernel implements BridgeInterface
 
         // get contents
         ob_start();
-        $content = $syResponse->getContent();
-        if ($content === false) {
-            $syResponse->sendContent();
-            $content = @ob_get_clean();
-        } else {
-            $content = $syResponse->getContent();
-            @ob_end_flush();
-        }
+        $syResponse->sendContent();
+        $content = @ob_get_clean();
 
         if ($stdout) {
             $content = $stdout . $content;

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
-use Symfony\Component\HttpFoundation\StreamedResponse as SymfonyStreamedResponse;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Illuminate\Contracts\Http\Kernel;
 
@@ -290,7 +289,8 @@ class HttpKernel implements BridgeInterface
 
         // get contents
         ob_start();
-        if ($syResponse instanceof SymfonyStreamedResponse) {
+        $content = $syResponse->getContent();
+        if ($content === false) {
             $syResponse->sendContent();
             $content = @ob_get_clean();
         } else {

--- a/tests/SymfonyBootstrapTest.php
+++ b/tests/SymfonyBootstrapTest.php
@@ -83,4 +83,26 @@ class SymfonyBootstrapTest extends TestCase
         $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('Received JSON: {"some_json_array":[{"map1":"value1"},{"map2":"value2"}]}', (string)$response->getBody());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testStreamedResponse()
+    {
+        putenv('APP_KERNEL_NAMESPACE=PHPPM\\Tests\\SymfonyMocks\\');
+        $bridge = new HttpKernel();
+        $bridge->bootstrap('Symfony', 'test', true);
+
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $request->method('getHeader')->with('Cookie')->willReturn([]);
+        $request->method('getQueryParams')->willReturn([]);
+        $request->method('getUploadedFiles')->willReturn([]);
+        $request->method('getMethod')->willReturn('GET');
+
+        $_SERVER['REQUEST_URI'] = '/streamed';
+
+        $response = $bridge->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('streamed data', (string)$response->getBody());
+    }
 }

--- a/tests/SymfonyMocks/Kernel.php
+++ b/tests/SymfonyMocks/Kernel.php
@@ -4,6 +4,7 @@ namespace PHPPM\Tests\SymfonyMocks;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class Kernel
 {
@@ -69,6 +70,13 @@ class Kernel
                 return new Response('Received JSON: '.$request->getContent(), 201);
             }
         } elseif ($request->getMethod() == 'GET') {
+
+            if ($request->getPathInfo() == '/streamed') {
+                return new StreamedResponse(function () {
+                    echo 'streamed data';
+                }, 200);
+            }
+
             // Simple get request
             return new Response('Success', 200);
         }

--- a/tests/SymfonyMocks/Kernel.php
+++ b/tests/SymfonyMocks/Kernel.php
@@ -70,7 +70,6 @@ class Kernel
                 return new Response('Received JSON: '.$request->getContent(), 201);
             }
         } elseif ($request->getMethod() == 'GET') {
-
             if ($request->getPathInfo() == '/streamed') {
                 return new StreamedResponse(function () {
                     echo 'streamed data';


### PR DESCRIPTION
Custom streaming response classes must return false on getContent(), just like StreamingResponse and BinaryFileResponse do.
The responses aren't streamed yet though.