### PR TITLE
Use illuminate's Request::createFromBase to create laravel requests

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -187,6 +187,10 @@ class HttpKernel implements BridgeInterface
 
         $syRequest->setMethod($method);
 
+        if ($syRequest instanceof \Illuminate\Http\Request && $syRequest->isJson()) {
+            $syRequest->request = $syRequest->json();
+        }
+
         return $syRequest;
     }
 


### PR DESCRIPTION
This PR fixes #136.

There are now two different bootstrapper for laravel, one for v4 and one for v5. This was the easiest way to fix the issue mentioned in #136 without changing too much of the existing code. Please let me know what you think about this structure. I have a few more ideas in mind how you could implement this, but they require a lot more refactoring.

I'll add some tests once you're okay with the implementation and I've figured out how to test the mapper sensibly.