### PR TITLE
Symfony bootstrap cleanup, the new 'kernel.reset' tag should do the job

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -2,12 +2,12 @@
 
 namespace PHPPM\Bootstraps;
 
-use PHPPM\Symfony\StrongerNativeSessionStorage;
 use PHPPM\Utils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Contracts\Service\ResetInterface;
 use function PHPPM\register_file;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * A default bootstrap for the Symfony framework
@@ -39,7 +39,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
     /**
      * Create a Symfony application
      *
-     * @return \AppKernel
+     * @return KernelInterface
      * @throws \Exception
      */
     public function getApplication()
@@ -67,27 +67,6 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
 
         //since we need to change some services, we need to manually change some services
         $app = new $class($this->appenv, $this->debug);
-
-        // We need to change some services, before the boot, because they would
-        // otherwise be instantiated and passed to other classes which makes it
-        // impossible to replace them.
-
-        Utils::bindAndCall(function () use ($app) {
-            // init bundles
-            $app->initializeBundles();
-
-            // init container
-            $app->initializeContainer();
-        }, $app);
-
-        Utils::bindAndCall(function () use ($app) {
-            foreach ($app->getBundles() as $bundle) {
-                $bundle->setContainer($app->container);
-                $bundle->boot();
-            }
-
-            $app->booted = true;
-        }, $app);
 
         if ($this->debug) {
             Utils::bindAndCall(function () use ($app) {
@@ -149,25 +128,23 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
     /**
      * Does some necessary preparation before each request.
      *
-     * @param \AppKernel $app
+     * @param KernelInterface $app
      */
     public function preHandle($app)
     {
-        //resets Kernels startTime, so Symfony can correctly calculate the execution time
-        Utils::hijackProperty($app, 'startTime', microtime(true));
     }
 
     /**
      * Does some necessary clean up after each request.
      *
-     * @param \AppKernel $app
+     * @param KernelInterface $app
      */
     public function postHandle($app)
     {
         $container = $app->getContainer();
 
         if ($container->has('doctrine')) {
-            $doctrineRegistry = $container->get("doctrine");
+            $doctrineRegistry = $container->get('doctrine');
             if (!$doctrineRegistry instanceof ResetInterface) {
                 foreach ($doctrineRegistry->getManagers() as $curManagerName => $curManager) {
                     if (!$curManager->isOpen()) {
@@ -177,11 +154,6 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
                     }
                 }
             }
-        }
-
-        //resets stopwatch, so it can correctly calculate the execution time
-        if ($container->has('debug.stopwatch')) {
-            $container->get('debug.stopwatch')->__construct();
         }
 
         //Symfony\Bundle\TwigBundle\Loader\FilesystemLoader
@@ -195,83 +167,10 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
             }, $twigLoader);
         }
 
-        //reset Webpack Encore file list
-        Utils::bindAndCall(function () use ($container) {
-            if (isset($container->privates['webpack_encore.entrypoint_lookup'])) {
-                $container->privates['webpack_encore.entrypoint_lookup']->reset();
-            }
-        }, $container);
-
         //reset all profiler stuff currently supported
-        if ($container->has('profiler')) {
-            $profiler = $container->get('profiler');
-
-            // since Symfony does not reset Profiler::disable() calls after each request, we need to do it,
-            // so the profiler bar is visible after the second request as well.
-            $profiler->enable();
-
-            //PropelLogger
-            if ($container->has('propel.logger')) {
-                $propelLogger = $container->get('propel.logger');
-                Utils::hijackProperty($propelLogger, 'queries', []);
-            }
-
-            //Doctrine
-            //Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector
-            if ($profiler->has('db')) {
-                Utils::bindAndCall(function () {
-                    //$logger: \Doctrine\DBAL\Logging\DebugStack
-                    foreach ($this->loggers as $logger) {
-                        Utils::hijackProperty($logger, 'queries', []);
-                    }
-                }, $profiler->get('db'), null, 'Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector');
-            }
-
-            //EventDataCollector
-            if ($profiler->has('events')) {
-                Utils::hijackProperty($profiler->get('events'), 'data', [
-                    'called_listeners' => [],
-                    'not_called_listeners' => [],
-                ]);
-            }
-
-            //TwigDataCollector
-            if ($profiler->has('twig')) {
-                Utils::bindAndCall(function () {
-                    Utils::hijackProperty($this->profile, 'profiles', []);
-                }, $profiler->get('twig'));
-            }
-
-            //Logger
-            if ($container->has('logger')) {
-                $logger = $container->get('logger');
-                Utils::bindAndCall(function () {
-                    if (\method_exists($this, 'getDebugLogger') && $debugLogger = $this->getDebugLogger()) {
-                        //DebugLogger
-                        Utils::hijackProperty($debugLogger, 'records', []);
-                    }
-                }, $logger);
-            }
-
-            //SwiftMailer logger
-            //Symfony\Bundle\SwiftmailerBundle\DataCollector\MessageDataCollector
-            if ($container->hasParameter('swiftmailer.mailers')) {
-                $mailers = $container->getParameter('swiftmailer.mailers');
-                foreach ($mailers as $name => $mailer) {
-                    $loggerName = sprintf('swiftmailer.mailer.%s.plugin.messagelogger', $name);
-                    if ($container->has($loggerName)) {
-                        /** @var \Swift_Plugins_MessageLogger $logger */
-                        $logger = $container->get($loggerName);
-                        $logger->clear();
-                    }
-                }
-            }
-
-            //Symfony\Bridge\Swiftmailer\DataCollector\MessageDataCollector
-            if ($container->has('swiftmailer.plugin.messagelogger')) {
-                $logger = $container->get('swiftmailer.plugin.messagelogger');
-                $logger->clear();
-            }
+        if ($container->has('propel.logger')) {
+            $propelLogger = $container->get('propel.logger');
+            Utils::hijackProperty($propelLogger, 'queries', []);
         }
     }
 }

--- a/tests/Fixtures/Symfony/Controller/GetController.php
+++ b/tests/Fixtures/Symfony/Controller/GetController.php
@@ -2,11 +2,10 @@
 
 namespace PHPPM\Tests\Fixtures\Symfony\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class GetController extends Controller
+class GetController
 {
     /**
      * @Route("/get")

--- a/tests/Fixtures/Symfony/Controller/PostJsonController.php
+++ b/tests/Fixtures/Symfony/Controller/PostJsonController.php
@@ -2,12 +2,11 @@
 
 namespace PHPPM\Tests\Fixtures\Symfony\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class PostJsonController extends Controller
+class PostJsonController
 {
     /**
      * @Route("/json", methods={"POST"})

--- a/tests/Fixtures/Symfony/Controller/StreamedController.php
+++ b/tests/Fixtures/Symfony/Controller/StreamedController.php
@@ -2,11 +2,10 @@
 
 namespace PHPPM\Tests\Fixtures\Symfony\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
-class StreamedController extends Controller
+class StreamedController
 {
     /**
      * @Route("/streamed")

--- a/tests/Fixtures/Symfony/Controller/UploadController.php
+++ b/tests/Fixtures/Symfony/Controller/UploadController.php
@@ -2,12 +2,11 @@
 
 namespace PHPPM\Tests\Fixtures\Symfony\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class UploadController extends Controller
+class UploadController
 {
     /**
      * @Route("/upload", methods={"POST"})

--- a/tests/Fixtures/Symfony/config/bundles.php
+++ b/tests/Fixtures/Symfony/config/bundles.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    \Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
 ];

--- a/tests/Fixtures/Symfony/config/services.yaml
+++ b/tests/Fixtures/Symfony/config/services.yaml
@@ -1,3 +1,17 @@
 services:
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+    public: false       # Allows optimizing the container by removing unused services; this also means
+                        # fetching services directly from the container via $container->get() won't work.
+                        # The best practice is to be explicit about your dependencies anyway.
+
+  # makes classes in src/ available to be used as services
+  # this creates a service per class whose id is the fully-qualified class name
+  PHPPM\Tests\Fixtures\Symfony\Controller\:
+    resource: '../Controller/*'
+    tags: ['controller.service_arguments']
+
 framework:
   secret: foobar


### PR DESCRIPTION
All the custom hijacking shouldn't be needed anymore afther SF 3.4 added the `kernel.reset` tag. Not so sure about the logger and swiftmailer hijacks