### PR TITLE
Only register twig files when debugging

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -150,7 +150,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
 
         //Symfony\Bundle\TwigBundle\Loader\FilesystemLoader
         //->Twig_Loader_Filesystem
-        if ($container->has('twig.loader')) {
+        if ($this->debug && $container->has('twig.loader')) {
             $twigLoader = $container->get('twig.loader');
             Utils::bindAndCall(function () use ($twigLoader) {
                 foreach ($twigLoader->cache as $path) {


### PR DESCRIPTION
the `register_file` function already checks if we're in debug mode and the files are actually never added in production, but the function call loop is uselessly iterated after every request, even in production