### PR TITLE
[BC-Break] Add request and response object to the preHandle and postHandle hooks

### DIFF
--- a/Bootstraps/HooksInterface.php
+++ b/Bootstraps/HooksInterface.php
@@ -2,8 +2,11 @@
 
 namespace PHPPM\Bootstraps;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
 interface HooksInterface
 {
-    public function preHandle($app);
-    public function postHandle($app);
+    public function preHandle($app, ServerRequestInterface $request);
+    public function postHandle($app, ServerRequestInterface $request, ResponseInterface $response);
 }

--- a/Bootstraps/Laravel.php
+++ b/Bootstraps/Laravel.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace PHPPM\Bootstraps;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * A default bootstrap for the Laravel framework
@@ -120,16 +122,19 @@ class Laravel implements
 
     /**
      * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param ServerRequestInterface $request
      */
-    public function preHandle($app)
+    public function preHandle($app, ServerRequestInterface $request)
     {
         //reset const LARAVEL_START, to get the correct timing
     }
 
     /**
      * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      */
-    public function postHandle($app)
+    public function postHandle($app, ServerRequestInterface $request, ResponseInterface $response)
     {
         //check if this is a lumen framework, if so, do not reset
         //note that lumen does not have the getProvider method

--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -4,6 +4,8 @@ namespace PHPPM\Bootstraps;
 
 use PHPPM\Symfony\StrongerNativeSessionStorage;
 use PHPPM\Utils;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use function PHPPM\register_file;
 
@@ -116,8 +118,9 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
      * Does some necessary preparation before each request.
      *
      * @param \AppKernel $app
+     * @param ServerRequestInterface $request
      */
-    public function preHandle($app)
+    public function preHandle($app, ServerRequestInterface $request)
     {
         //resets Kernels startTime, so Symfony can correctly calculate the execution time
         Utils::hijackProperty($app, 'startTime', microtime(true));
@@ -127,8 +130,10 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
      * Does some necessary clean up after each request.
      *
      * @param \AppKernel $app
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      */
-    public function postHandle($app)
+    public function postHandle($app, ServerRequestInterface $request, ResponseInterface $response)
     {
         $container = $app->getContainer();
 

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -81,7 +81,7 @@ class HttpKernel implements BridgeInterface
         ob_start();
 
         if ($this->bootstrap instanceof HooksInterface) {
-            $this->bootstrap->preHandle($this->application);
+            $this->bootstrap->preHandle($this->application, $request);
         }
 
         $syResponse = $this->application->handle($syRequest);
@@ -98,7 +98,7 @@ class HttpKernel implements BridgeInterface
         }
 
         if ($this->bootstrap instanceof HooksInterface) {
-            $this->bootstrap->postHandle($this->application);
+            $this->bootstrap->postHandle($this->application, $request, $response);
         }
 
         return $response;


### PR DESCRIPTION
I think it's reasonable to be able to access the request and response in the `preHandle` and `postHandle` hooks.

For example, I'm trying to trace some stuff using Blackfire.io and those hooks are the earliest possible place where I can start the probes. But I don't want to probe every request, only those that have a specific header, that's what I can't do right now. My only choice right now is starting the probe inside the app, in a  Symfony request listener, but that's a bit too late if I want to profile the whole thing.