### PR TITLE
Deleting unused variables after Response return

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -100,6 +100,10 @@ class HttpKernel implements BridgeInterface
         if ($this->bootstrap instanceof HooksInterface) {
             $this->bootstrap->postHandle($this->application);
         }
+        
+        $request = null;
+        $syRequest = null;
+        $syResponse = null;
 
         return $response;
     }
@@ -190,6 +194,12 @@ class HttpKernel implements BridgeInterface
         if ($syRequest instanceof \Illuminate\Http\Request && $syRequest->isJson()) {
             $syRequest->request = $syRequest->json();
         }
+
+        $post = null;
+        $uploadedFiles = null;
+        $mapFiles = null;
+        $cookies = null;
+        $query = null;
 
         return $syRequest;
     }

--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -312,6 +312,12 @@ class HttpKernel implements BridgeInterface
             }
         }
 
+        $headers = null;
+        $cookies = null;
+        $nativeHeaders = null;
+        $content = null;
+        $stdout = null;
+
         return $psrResponse;
     }
 


### PR DESCRIPTION
- This is part of this discussion https://github.com/php-pm/php-pm/issues/448

# Rationale
HttpKernel handle method is injected as an anonymous function, and because of that, internal memory positions used inside this function is only removed when the GC is applied.
In order to avoid memory incremental, we can set to null these variables, and this used memory space will automaticaly be released.

# How to check the impact
- Create an application using HttpKernel as the bridge
- Add this line before the response is returned in the method `handle`. - `syslog(1, memory_get_usage(false));`
- Use the application and tailf the syslog.
- You will find that the memory increases after each call
- By adding these lines, the memory will be stable (you may not see each line the, because syslog group them when are equal)