### PR TITLE
Fix SF 4.3 deprecation with Dotenv

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -53,7 +53,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
 
         // environment loading as of Symfony 3.3
         if (!getenv('APP_ENV') && class_exists('Symfony\Component\Dotenv\Dotenv') && file_exists(realpath('.env'))) {
-            (new \Symfony\Component\Dotenv\Dotenv())->load(realpath('.env'));
+            (new \Symfony\Component\Dotenv\Dotenv(true))->load(realpath('.env'));
         }
 
         $namespace = getenv('APP_KERNEL_NAMESPACE') ?: '\App\\';


### PR DESCRIPTION
Since SF 4.3, the `Dotenv` component now explicitly requires that we enable the use of `putenv()` calls. Since we use `getenv()` later on the bootstrap, the property needs to be `true`.