### PR TITLE
Fix bad empty headers

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -277,7 +277,7 @@ class HttpKernel implements BridgeInterface
 
         if (isset($nativeHeaders['Set-Cookie'])) {
             $headers['Set-Cookie'] = array_merge((array)$nativeHeaders['Set-Cookie'], $cookies);
-        } else {
+        } elseif ($cookies) {
             $headers['Set-Cookie'] = $cookies;
         }
 


### PR DESCRIPTION
With guzzlehttp/psr7 recent changes (https://github.com/guzzle/psr7/pull/250/files#diff-5abca4d9d5693da46d10a54795b1192dR164) a header with an empty array is now not allowed. Therefore, if there are no cookies to be sent, we shouldn't even set the cookies header. Tests were currently failing if installing guzzlehttp/psr7 >= 1.6.1