### PR TITLE
Don't reset Registry if it implements ResetInterface

### DIFF
--- a/Bootstraps/Symfony.php
+++ b/Bootstraps/Symfony.php
@@ -6,6 +6,7 @@ use PHPPM\Symfony\StrongerNativeSessionStorage;
 use PHPPM\Utils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Contracts\Service\ResetInterface;
 use function PHPPM\register_file;
 
 /**
@@ -167,11 +168,13 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
 
         if ($container->has('doctrine')) {
             $doctrineRegistry = $container->get("doctrine");
-            foreach ($doctrineRegistry->getManagers() as $curManagerName => $curManager) {
-                if (!$curManager->isOpen()) {
-                    $doctrineRegistry->resetManager($curManagerName);
-                } else {
-                    $curManager->clear();
+            if (!$doctrineRegistry instanceof ResetInterface) {
+                foreach ($doctrineRegistry->getManagers() as $curManagerName => $curManager) {
+                    if (!$curManager->isOpen()) {
+                        $doctrineRegistry->resetManager($curManagerName);
+                    } else {
+                        $curManager->clear();
+                    }
                 }
             }
         }
@@ -198,7 +201,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
                 $container->privates['webpack_encore.entrypoint_lookup']->reset();
             }
         }, $container);
-        
+
         //reset all profiler stuff currently supported
         if ($container->has('profiler')) {
             $profiler = $container->get('profiler');


### PR DESCRIPTION
Aside from the other issues DoctrineBundle 2.0.6 introduced, it also results in resetting the entity manager twice on every request (one reset is done from Symfony and the other one from us).

This PR prevents this behavior by checking whether the `Registry` implements `ResetInterface` and not executing our reset if it does.