### PR TITLE
Fix file upload in Symfony v5

### DIFF
--- a/Bridges/HttpKernel.php
+++ b/Bridges/HttpKernel.php
@@ -183,14 +183,27 @@ class HttpKernel implements BridgeInterface
                     if (UPLOAD_ERR_OK == $file->getError()) {
                         file_put_contents($tmpname, (string)$file->getStream());
                     }
-                    $file = new SymfonyFile(
-                        $tmpname,
-                        $file->getClientFilename(),
-                        $file->getClientMediaType(),
-                        $file->getSize(),
-                        $file->getError(),
-                        true
-                    );
+                    $class = new \ReflectionClass(SymfonyFile::class);
+                    if (count($class->getConstructor()->getParameters()) === 6) {
+                        // Symfony < v4.1
+                        $file = new SymfonyFile(
+                            $tmpname,
+                            $file->getClientFilename(),
+                            $file->getClientMediaType(),
+                            $file->getSize(),
+                            $file->getError(),
+                            true
+                        );
+                    } else {
+                        $file = new SymfonyFile(
+                            $tmpname,
+                            $file->getClientFilename(),
+                            $file->getClientMediaType(),
+                            $file->getError(),
+                            true
+                        );
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
UploadedFile lost a parameter in Symfony v4.1, and compatbility was removed in v5.
The number of parameters is checked using reflection.