### PR TITLE
Add support for the new .env files structure

### DIFF
--- a/src/Bootstraps/Symfony.php
+++ b/src/Bootstraps/Symfony.php
@@ -57,7 +57,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
         if (!getenv('APP_ENV') && class_exists(Dotenv::class) && file_exists(realpath('.env'))) {
             //Symfony >=5.1 compatibility
             if (method_exists(Dotenv::class, 'usePutenv')) {
-                (new Dotenv())->usePutenv()->load(realpath('.env'));
+                (new Dotenv())->usePutenv()->bootEnv(realpath('.env'));
             } else {
                 (new Dotenv(true))->load(realpath('.env'));
             }


### PR DESCRIPTION
Sometime ago (https://symfony.com/doc/current/configuration/dot-env-changes.html) , Symfony changed the way .env files were loaded and now accepts a .env.local or a .env.dev file. Right now, php-pm is only loading the .env file. With this change, Symfony now will load all the relevant .env.* files too