### PR TITLE
Add support for Symfony 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+/.idea/
 /vendor/
 composer.lock
 tests/Fixtures/Symfony/cache
 tests/Fixtures/Symfony/logs
 tests/Fixtures/Symfony/var
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "license": "MIT",
     "require": {
         "php-pm/php-pm": "^2.0",
-        "symfony/http-foundation": "^3.4|^4.2.12|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0",
+        "symfony/http-foundation": "^4.2.12|^5.0|^6.0",
+        "symfony/http-kernel": "^4.0|^5.0|^6.0",
         "guzzlehttp/psr7": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "symfony/framework-bundle": "^3.4|^4.1.12|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0",
+        "phpunit/phpunit": "^9.5",
+        "symfony/framework-bundle": "^4.1.12|^5.0|^6.0",
+        "symfony/yaml": "^4.0|^5.0|^6.0",
         "doctrine/annotations": "^1.6"
     },
     "autoload": {

--- a/tests/Fixtures/Symfony/Kernel.php
+++ b/tests/Fixtures/Symfony/Kernel.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends \Symfony\Component\HttpKernel\Kernel
 {
@@ -14,7 +14,7 @@ class Kernel extends \Symfony\Component\HttpKernel\Kernel
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir() . '/config/bundles.php';
         foreach ($contents as $class => $envs) {
@@ -36,14 +36,14 @@ class Kernel extends \Symfony\Component\HttpKernel\Kernel
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RoutingConfigurator $routes)
     {
         $confDir = $this->getProjectDir() . '/config';
 
-        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS);
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }

--- a/tests/SymfonyBootstrapTest.php
+++ b/tests/SymfonyBootstrapTest.php
@@ -12,12 +12,12 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class SymfonyBootstrapTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         ProcessSlave::$slave = new ProcessSlaveDouble();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         $fs = new Filesystem();
         $fs->remove(__DIR__.'/Fixtures/Symfony/var');


### PR DESCRIPTION
Remove SF 3.4 as it is EOL'd as of November 2021 and no longer receives updates (https://symfony.com/releases/3.4)