### PR TITLE
Update deps to address reported security issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "license": "MIT",
     "require": {
         "php-pm/php-pm": "^2.0",
-        "symfony/http-foundation": "^4.2.12|^5.0|^6.0",
+        "symfony/http-foundation": "^4.1.13|^5.1.5|^6.0",
         "symfony/http-kernel": "^4.0|^5.0|^6.0",
         "guzzlehttp/psr7": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/framework-bundle": "^4.1.12|^5.0|^6.0",
+        "symfony/framework-bundle": "^4.1.13|^5.1.5|^6.0",
         "symfony/yaml": "^4.0|^5.0|^6.0",
         "doctrine/annotations": "^1.6"
     },


### PR DESCRIPTION
Ref: https://github.com/php-pm/php-pm-httpkernel/pull/179#discussion_r781298506

I would suggest further constraining the SF versions to only the currently supported as many branches are no longer receiving any updates (see: https://symfony.com/releases). I would suggest: `^4.4|^5.4|^6.0` as 5.3 ends support this month.