### PR TITLE
Fixed Symfony Bootstraps Issue, for Symfony6 HttpFoundation\Request bc break 

### DIFF
--- a/src/Bootstraps/Symfony.php
+++ b/src/Bootstraps/Symfony.php
@@ -108,7 +108,8 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
         }
 
         if ($trustedProxies = getenv('TRUSTED_PROXIES')) {
-            Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+            Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
+
         }
 
         if ($trustedHosts = getenv('TRUSTED_HOSTS')) {


### PR DESCRIPTION
Symfony Bootstraps used HttpFoundation\Request constants for booting application.
in Symfony6 was removed deprecated const Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL
was replaced on. ```HEADER_X_FORWARDED_FOR | HEADER_X_FORWARDED_HOST | HEADER_X_FORWARDED_PORT | HEADER_X_FORWARDED_PROTO``` as described on symfony recommendation.