### PR TITLE
remove check if APP_ENV is given to load dotenv

### DIFF
--- a/src/Bootstraps/Symfony.php
+++ b/src/Bootstraps/Symfony.php
@@ -54,7 +54,7 @@ class Symfony implements BootstrapInterface, HooksInterface, ApplicationEnvironm
         }
 
         // environment loading as of Symfony 3.3
-        if (!getenv('APP_ENV') && class_exists(Dotenv::class) && file_exists(realpath('.env'))) {
+        if (class_exists(Dotenv::class) && file_exists(realpath('.env'))) {
             //Symfony >=5.1 compatibility
             if (method_exists(Dotenv::class, 'usePutenv')) {
                 (new Dotenv())->usePutenv()->bootEnv(realpath('.env'));


### PR DESCRIPTION
In most symfony projects, there is a `.env` in the project root with default variables, f.ex.:

```
REDIS_DSN=redis://redis
```

If we run a docker-container with the env variable `APP_ENV=prod`, none of the default variables will be loaded because there is a check in the Symfony bridge, that the `.env` is only loaded if `APP_ENV` does not exist.


In our understanding, this should be removed and the default variables should always be loaded. 
