### PR TITLE
Guzzle psr7 v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php-pm/php-pm": "^2.0",
         "symfony/http-foundation": "^4.2.12|^5.0|^6.0",
         "symfony/http-kernel": "^4.0|^5.0|^6.0",
-        "guzzlehttp/psr7": "^1.5"
+        "guzzlehttp/psr7": "^1.5|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/Bridges/HttpKernel.php
+++ b/src/Bridges/HttpKernel.php
@@ -308,8 +308,8 @@ class HttpKernel implements BridgeInterface
         if (!isset($headers['Content-Length'])) {
             $psrResponse = $psrResponse->withAddedHeader('Content-Length', strlen($content));
         }
-
-        $psrResponse = $psrResponse->withBody(Psr7\stream_for($content));
+        $body = class_exists('\GuzzleHttp\Psr7\Utils') ? Psr7\Utils::streamFor($content) : Psr7\stream_for($content);
+        $psrResponse = $psrResponse->withBody($body);
 
         foreach ($this->tempFiles as $tmpname) {
             if (file_exists($tmpname)) {


### PR DESCRIPTION
Then I tried to install the library, I've got the error:
```
php-pm/httpkernel-adapter 2.3.0 requires guzzlehttp/psr7 ^1.5 -> found guzzlehttp/psr7[1.5.0, ..., 1.9.0] but the package is fixed to 2.4.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```
The PR adds guzzlehttp/psr7 version v2 compatibility